### PR TITLE
Add Redis custom dictionary and HTTP API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 *.txt
-go.mod
-go.sum
 *.dawg

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+
+	"corrector/internal/customdict"
+)
+
+func main() {
+	redisAddr := getenv("REDIS_ADDR", "localhost:6379")
+	redisPassword := os.Getenv("REDIS_PASSWORD")
+	redisDB := getEnvInt("REDIS_DB", 0)
+
+	client := redis.NewClient(&redis.Options{
+		Addr:     redisAddr,
+		Password: redisPassword,
+		DB:       redisDB,
+	})
+
+	dict := customdict.New(client)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/custom-word", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var req struct {
+			Word string `json:"word"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Word == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid request"})
+			return
+		}
+		if err := dict.Add(req.Word); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	mux.HandleFunc("/api/v1/custom-word/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.NotFound(w, r)
+			return
+		}
+		word := strings.TrimPrefix(r.URL.Path, "/api/v1/custom-word/")
+		if word == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "word is required"})
+			return
+		}
+		if err := dict.Remove(word); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	addr := getenv("HTTP_ADDR", ":8080")
+	log.Printf("listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+func getenv(key, def string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+func getEnvInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	if i, err := strconv.Atoi(v); err == nil {
+		return i
+	}
+	return def
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module corrector
+
+go 1.24.3
+
+require (
+	github.com/edsrzf/mmap-go v1.2.0
+	github.com/redis/go-redis/v9 v9.12.1
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/edsrzf/mmap-go v1.2.0 h1:hXLYlkbaPzt1SaQk+anYwKSRNhufIDCchSPkUD6dD84=
+github.com/edsrzf/mmap-go v1.2.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
+github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
+github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/customdict/customdict.go
+++ b/internal/customdict/customdict.go
@@ -1,0 +1,33 @@
+package customdict
+
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// CustomDict wraps a Redis client to store custom dictionary words.
+type CustomDict struct {
+	client *redis.Client
+	key    string
+}
+
+// New creates a new CustomDict with the provided Redis client.
+func New(client *redis.Client) *CustomDict {
+	return &CustomDict{client: client, key: "custom_dict"}
+}
+
+// Add inserts a word into the custom dictionary.
+func (cd *CustomDict) Add(word string) error {
+	return cd.client.SAdd(context.Background(), cd.key, word).Err()
+}
+
+// Remove deletes a word from the custom dictionary.
+func (cd *CustomDict) Remove(word string) error {
+	return cd.client.SRem(context.Background(), cd.key, word).Err()
+}
+
+// All returns all words stored in the custom dictionary.
+func (cd *CustomDict) All() ([]string, error) {
+	return cd.client.SMembers(context.Background(), cd.key).Result()
+}


### PR DESCRIPTION
## Summary
- implement internal custom dictionary backed by Redis with Add, Remove and All methods
- add HTTP server exposing endpoints to manage custom dictionary
- add Go module definition

## Testing
- `go build ./...`
- `go test -vet=off ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6cfcbf448832381edaa630b3c0f07