### PR TITLE
feat: add redis-backed custom word support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,12 +31,12 @@ func main() {
 	}
 
 	dict := "ru.txt"
-	corrector, err := sc.NewSpellCorrector(cfg, dict)
+	corrector, err := sc.NewSpellCorrector(cfg, dict, nil)
 	if err != nil {
 		log.Fatalf("Ошибка инициализации: %v", err)
 	}
 
-	fmt.Println("Spell Corrector v2. Введите текст (quit для выхода).\n")
+	fmt.Println("Spell Corrector v2. Введите текст (quit для выхода).")
 	scanner := bufio.NewScanner(os.Stdin)
 	for {
 		fmt.Print("Текст: ")


### PR DESCRIPTION
## Summary
- extend SpellCorrector with Redis-powered custom word handling
- load custom words during initialization and skip morphology on them
- expose AddCustomWord and RemoveCustomWord helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6d18058948323bdac4200e7eaa025