### PR TITLE
feat: provide alternative correction outputs

### DIFF
--- a/internal/corrector/config.go
+++ b/internal/corrector/config.go
@@ -33,7 +33,8 @@ type SuggestionInfo struct {
 }
 
 type CorrectionResult struct {
-	Original    string                 `json:"original"`
-	Corrected   string                 `json:"corrected"`
-	Suggestions map[int]SuggestionInfo `json:"suggestions"`
+	Original     string                 `json:"original"`
+	Corrected    string                 `json:"corrected"`
+	Alternatives []string               `json:"alternatives,omitempty"`
+	Suggestions  map[int]SuggestionInfo `json:"suggestions"`
 }


### PR DESCRIPTION
## Summary
- add `Alternatives` field to `CorrectionResult` for returning ranked alternate corrections
- generate alternative suggestions by substituting second-best candidates and sort by score

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6d322cbc483239d2ab5e20c6b9665